### PR TITLE
Allow for FlashResponder to handle interpolations in model name translations

### DIFF
--- a/lib/responders/flash_responder.rb
+++ b/lib/responders/flash_responder.rb
@@ -149,13 +149,14 @@ module Responders
     end
 
     def mount_i18n_options(status) #:nodoc:
+      controller_options = controller_interpolation_options
+
       options = {
         default: flash_defaults_by_namespace(status),
-        resource_name: resource_name,
-        downcase_resource_name: resource_name.downcase
+        resource_name: resource_name(controller_options),
+        downcase_resource_name: resource_name(controller_options).downcase
       }
 
-      controller_options = controller_interpolation_options
       if controller_options
         options.merge!(controller_options)
       end
@@ -172,9 +173,9 @@ module Responders
       end
     end
 
-    def resource_name
+    def resource_name(interpolation_options={})
       if resource.class.respond_to?(:model_name)
-        resource.class.model_name.human
+        resource.class.model_name.human(interpolation_options)
       else
         resource.class.name.underscore.humanize
       end

--- a/test/locales/en.yml
+++ b/test/locales/en.yml
@@ -1,4 +1,7 @@
 en:
+  activemodel:
+    models:
+      interpolated_address: '%{interpolation_value} Address'
   flash:
     actions:
       create:

--- a/test/responders/flash_responder_test.rb
+++ b/test/responders/flash_responder_test.rb
@@ -76,6 +76,16 @@ class PolymorphicAddesssController < AddressesController
   end
 end
 
+class InterpolatedResourceNameAddesssController < AddressesController
+  def flash_interpolation_options
+    { interpolation_value: "Funny" }
+  end
+
+  def create
+    respond_with(InterpolatedAddress.new)
+  end
+end
+
 module Admin
   class AddressesController < ::AddressesController
   end
@@ -271,5 +281,19 @@ class PolymorhicFlashResponderTest < ActionController::TestCase
   def test_polymorhic_respond_with
     post :create
     assert_equal "Address was successfully created.", flash[:notice]
+  end
+end
+
+class InterpolatedResourceNameFlashResponderTest < ActionController::TestCase
+  tests InterpolatedResourceNameAddesssController
+
+  def setup
+    Responders::FlashResponder.flash_keys = [ :notice, :alert ]
+    @controller.stubs(:polymorphic_url).returns("/")
+  end
+
+  def test_interpolated_resource_name_respond_with
+    post :create
+    assert_equal "Funny Address was successfully created.", flash[:notice]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -82,6 +82,10 @@ end
 class Address < Model
 end
 
+class InterpolatedAddress < Model
+  extend ActiveModel::Naming
+end
+
 class User < Model
 end
 


### PR DESCRIPTION
I bumped into this situation this week and was a little surprised I couldn't solve it via `#flash_interpolation_options`. Clearly this is a bit of a weird case but it also doesn't seem like there's any real downsides to supporting it. What do you think?
