### PR TITLE
System tests with Hotwire

### DIFF
--- a/lib/action_controller/responder.rb
+++ b/lib/action_controller/responder.rb
@@ -120,6 +120,7 @@ module ActionController #:nodoc:
   #
   # Using <code>respond_with</code> with a block follows the same syntax as <code>respond_to</code>.
   class Responder
+    cattr_accessor :redirect_status, default: :found
     attr_reader :controller, :request, :format, :resource, :resources, :options
 
     DEFAULT_ACTIONS_FOR_VERBS = {
@@ -204,7 +205,7 @@ module ActionController #:nodoc:
       elsif has_errors? && default_action
         render error_rendering_options
       else
-        redirect_to navigation_location
+        redirect_to navigation_location, status: redirect_status
       end
     end
 

--- a/lib/responders.rb
+++ b/lib/responders.rb
@@ -20,6 +20,7 @@ module Responders
     config.responders = ActiveSupport::OrderedOptions.new
     config.responders.flash_keys = [:notice, :alert]
     config.responders.namespace_lookup = false
+    config.responders.redirect_status = :found
 
     # Add load paths straight to I18n, so engines and application can overwrite it.
     require "active_support/i18n"
@@ -28,6 +29,7 @@ module Responders
     initializer "responders.flash_responder" do |app|
       Responders::FlashResponder.flash_keys = app.config.responders.flash_keys
       Responders::FlashResponder.namespace_lookup = app.config.responders.namespace_lookup
+      ActionController::Responder.redirect_status = app.config.redirect_status
     end
   end
 end

--- a/test/action_controller/respond_with_test.rb
+++ b/test/action_controller/respond_with_test.rb
@@ -639,6 +639,42 @@ class RespondWithControllerTest < ActionController::TestCase
     end
   end
 
+  def test_redirect_status_for_post
+    with_test_route_set do
+      with_redirect_status(:see_other) do
+        post :using_resource
+        assert_equal 303, @response.status
+      end
+    end
+  end
+
+  def test_redirect_status_for_post
+    with_test_route_set do
+      with_redirect_status(:see_other) do
+        patch :using_resource
+        assert_equal 303, @response.status
+      end
+    end
+  end
+
+  def test_redirect_status_for_post
+    with_test_route_set do
+      with_redirect_status(:see_other) do
+        put :using_resource
+        assert_equal 303, @response.status
+      end
+    end
+  end
+
+  def test_redirect_status_for_post
+    with_test_route_set do
+      with_redirect_status(:see_other) do
+        delete :using_resource
+        assert_equal 303, @response.status
+      end
+    end
+  end
+
   private
 
   def with_test_route_set
@@ -654,6 +690,13 @@ class RespondWithControllerTest < ActionController::TestCase
       end
       yield
     end
+  end
+
+  def with_redirect_status(status)
+    old_status = ActionController::Responder.redirect_status
+    ActionController::Responder.redirect_status = status
+    yield
+    ActionController::Responder.redirect_status = old_status
   end
 end
 


### PR DESCRIPTION
This PR adds system tests for Responders with a dummy Rails app that's using Hotwire.

Hotwire currently handles non-GET requests slightly differently if you submit a form with a `_method` or if you have a link using `data-turbo-method`. This adds a test for both of those cases to confirm that the redirect is handled correctly using a 303 to safely handle both cases.

With a 302, the `data-turbo-method` will actually forward the request method to the redirect URL. This results in a `DELETE /posts/1` redirecting to `DELETE /posts`. A 303 will change the redirect to a `GET /posts` correctly.

**Why is this necessary?**
`button_to` will generate a form with `method="post"` and `_method="delete"` as a hidden field. It sends a POST request to Rails, which then gets handled like a `DELETE`.

`data-turbo-method="delete"` actually makes a `DELETE` request. https://github.com/hotwired/turbo/blob/8221c1e5f2021c41c3ecada0dde55bae9ee18380/src/core/session.ts#L143-L147

Related: heartcombo/devise#5410