### PR TITLE
Fix typo, compatibilty -> compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Update your bundle and run the install generator:
     $ bundle install
     $ rails g responders:install
 
-If you are including this gem to support backwards compatibilty for responders in previous releases of Rails, you only need to include the gem and bundle.
+If you are including this gem to support backwards compatibility for responders in previous releases of Rails, you only need to include the gem and bundle.
 
     $ bundle install
 


### PR DESCRIPTION
Found by `typos --format brief`