### PR TITLE
fix to_xml for unprocessable_entity responses

### DIFF
--- a/lib/action_controller/responder.rb
+++ b/lib/action_controller/responder.rb
@@ -303,6 +303,10 @@ module ActionController # :nodoc:
       { errors: resource.errors }
     end
 
+    def xml_resource_errors
+      resource.errors.to_a.to_xml({ root: "errors", skip_types: true })
+    end
+
     def response_overridden?
       @default_response.present?
     end


### PR DESCRIPTION
Rails 7+ has removed `ActiveModel::Errors#to_xml` which responders was relying on to emit :unprocessable_entity errors in xml format. You'll see something like this if it tries to render the error collection into a response:  

```
undefined method `bytesize' for #<ActiveModel::Error attribute=name, type=blank, options={}>
```

I cobbled together a fix for this by pulling out the formatting method used in [Rails 6](https://github.com/rails/rails/blob/v6.1.7.8/activemodel/lib/active_model/errors.rb#L299) to restore the functionality. Unsure if this works in Rails <5 so it might be worth gating with a conditional.